### PR TITLE
Recommend extending `project-prefix-map` in `README.org`

### DIFF
--- a/README.org
+++ b/README.org
@@ -75,16 +75,18 @@ Install directly from source (a.k.a this repository) using =straight.el=. The co
   (use-package consult-project-extra
     :straight (consult-project-extra :type git :host github :repo "Qkessler/consult-project-extra")
     :bind
-    (("C-c p f" . consult-project-extra-find)
-     ("C-c p o" . consult-project-extra-find-other-window)))
+    (:map project-prefix-map
+     ("f" . consult-project-extra-find)
+     ("o" . consult-project-extra-find-other-window)))
 
   ;; or install from melpa
 
   (use-package consult-project-extra
     :straight t
     :bind
-    (("C-c p f" . consult-project-extra-find)
-     ("C-c p o" . consult-project-extra-find-other-window)))
+    (:map project-prefix-map
+     ("f" . consult-project-extra-find)
+     ("o" . consult-project-extra-find-other-window)))
 #+end_src
 
 ** Use-package or package-install


### PR DESCRIPTION
I would recommend binding the additional commands to `project-prefix-map`, which in my version of emacs 29 is by default bound to `C-x p` and not `C-c p`, which was used in the README example.

Using the project prefix map for all project commands is useful because it makes remembering and discovering commands easier, e.g. with `which-key`. I just type the project prefix and then get a dynamic menu of all commands in the keymap. Also, I'm free to re-define the project prefix key, e.g. I bound `project-prefix-map` to `SPC p` in evil-mode, but the user could also bind it to `C-c p` for all commands if he wanted to.

The downside is that by binding to `project-prefix-map` directly, we are overriding the keybindings for some built-in commands like `project-find-file`. Is this why you used `C-c p` as a prefix in the example? But to me it seems like `consult-project-extra-find` can replace `project-find-file`, so I don't mind overriding it. If overriding is desired, one could also use a syntax like 

``` emacs-lisp
(:map project-prefix-map
 ([remap project-find-file] . consult-project-extra-find))
```

Though I admit I haven't tested this version yet, so not sure that this exact syntax works.

But if you prefer using a separate prefix for the extra commands in the readme, feel free to reject this PR.