### PR TITLE
Delegate visiting files to consult to honour buffer display hints

### DIFF
--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -70,11 +70,11 @@
               :category 'file
               :state (consult--file-preview)
               :history 'file-name-history)))
-    (find-file (concat selected-root candidate))))
+    (consult--file-action (concat selected-root candidate))))
 
 (defun consult-project-extra--find-with-concat-root (candidate)
   "Find-file concatenating root with CANDIDATE."
-  (find-file (concat (project-root (project-current)) candidate)))
+  (consult--file-action (concat (project-root (project-current)) candidate)))
 
 ;; The default `consult--source-project-buffer' has the ?p as narrow key,
 ;; and therefore is in conflict with `consult-project-extra--source-project'.


### PR DESCRIPTION
If `find-file` is called directly in the action for file candidates, `consult-project-extra-find-other-window` will not work as expected as `consult--buffer-display` is never honoured, hence without this patch the file won't be visited in other window.

Consult version installed: `20231215.1505`.