### PR TITLE
Optimize consult-project-extra--project-files

### DIFF
--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -56,9 +56,17 @@
 
 (defun consult-project-extra--project-files (root)
   "Compute the project files given the ROOT."
+  (setq root (file-name-as-directory root))
   (let* ((project (consult-project-extra--project-with-root root))
-         (files (project-files project)))
-    (mapcar (lambda (f) (file-relative-name f root)) files)))
+         (project-files-relative-names t)
+         (files (project-files project))
+         (root-len (length root)))
+    (mapcar (lambda (f) (if (file-name-absolute-p f)
+                       (if (string-prefix-p root f)
+                           (substring f 0 root-len)
+                         (file-relative-name f root))
+                     f))
+            files)))
 
 (defun consult-project-extra--file (selected-root)
   "Create a view for selecting project files for the project at SELECTED-ROOT."


### PR DESCRIPTION
Unfortunately, `file-relative-name` can be pretty slow, slowing down this method on large repositories (e.g., the Linux kernel). The default `project-read-file-name-function` (`project--read-file-cpd-relative`) avoids this issue by using string prefixes; I've taken a similar approach here. This patch:

1. Allows the underling "project" backend to return relative file paths for us. According to the documentation, these relative file paths will always be relative to the project root.
2. If the file names are still absolute, it first tries to make them relative by removing the project root as a substring.
3. If all else fails, it falls back on calling file-relative-name.