### PR TITLE
Recursive Project Selection

### DIFF
--- a/README.org
+++ b/README.org
@@ -74,6 +74,7 @@ Install directly from source (a.k.a this repository) using =straight.el=. The co
 
   (use-package consult-project-extra
     :straight (consult-project-extra :type git :host github :repo "Qkessler/consult-project-extra")
+    :custom (consult-project-function #'consult-project-extra-project-fn) ;; Optional but recommended for a more consistent UI
     :bind
     (("C-c p f" . consult-project-extra-find)
      ("C-c p o" . consult-project-extra-find-other-window)))
@@ -82,6 +83,7 @@ Install directly from source (a.k.a this repository) using =straight.el=. The co
 
   (use-package consult-project-extra
     :straight t
+    :custom (consult-project-function #'consult-project-extra-project-fn) ;; Optional but recommended for a more consistent UI
     :bind
     (("C-c p f" . consult-project-extra-find)
      ("C-c p o" . consult-project-extra-find-other-window)))
@@ -100,7 +102,11 @@ Install with the built-in package-install (though I recommend investing in learn
 Or install using use-package
 #+begin_src emacs-lisp
   (use-package consult-project-extra
-    :ensure t)
+    :ensure t
+    :custom (consult-project-function #'consult-project-extra-project-fn) ;; Optional but recommended for a more consistent UI
+    :bind
+    (("C-c p f" . consult-project-extra-find)
+     ("C-c p o" . consult-project-extra-find-other-window)))
 #+end_src
 
 ** Manually

--- a/README.org
+++ b/README.org
@@ -8,6 +8,8 @@
 * Introduction
 consult-project-extra defines an endpoint for accessing different sources related to the common project workflow. Using [[https://github.com/minad/consult][Consult]]'s narrowing system, the user is able to access the current project's buffers, project files and all the known projects, in case they want to change projects quickly. consult-project-extra provides an extension to the default [[https://github.com/minad/consult][Consult]] functionality, using the built-in package =project.el=, defining the functions =consult-project-extra-find= and =consult-project-extra-find-other-window=. Furthermore, consult-project-extra only depends on consult, resulting in a lean and simple to maintain functionality.
 
+Additionally consult-project-extra provides optional integrations for [[https://github.com/domtronn/all-the-icons.el][all-the-icons]], [[https://github.com/oantolin/embark][embark]] and [[https://github.com/minad/marginalia][marginalia]], if those packages are installed.
+
 ⚠️ *NOTE*: This package has come to life adapting the great package [[https://gitlab.com/OlMon/consult-projectile][consult-projectile by OlMon]]. Most if not all credit should go to him, I have been using his package for months now. What inspired me to create this package is my recent effort to avoid most third party packages, specially if they prefer a newly defined interface over the built-in Emacs interface.
 
 ** Table of Contents :TOC:

--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -52,14 +52,14 @@
 
 ;;optional embark integration
 (with-eval-after-load 'embark
-  (defvar embark-project-map
+  (defvar consult-project-extra-embark-project-map
     (make-composed-keymap embark-file-map))
 
-  (defvar embark-project-file-map
-    (make-composed-keymap embark-project-map))
+  (defvar consult-project-extra-embark-project-file-map
+    (make-composed-keymap consult-project-extra-embark-project-map))
 
   (add-to-list 'embark-keymap-alist '(project embark-project-map))
-  (add-to-list 'embark-keymap-alist '(project-file embark-project-file-map)))
+  (add-to-list 'embark-keymap-alist '(project-file consult-project-extra-embark-project-file-map)))
 
 (defun consult-project-extra--project-with-root (root)
   "Return the project for a given project ROOT."

--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -89,7 +89,7 @@
 
 (defun consult-project-extra--find-with-concat-root (candidate)
   "Find-file concatenating root with CANDIDATE."
-  (consult--file-action (concat (project-root (project-current)) candidate)))
+  (consult--file-action (concat (consult--project-root) candidate)))
 
 ;; The default `consult--source-project-buffer' has the ?p as narrow key,
 ;; and therefore is in conflict with `consult-project-extra--source-project'.
@@ -106,8 +106,8 @@
                :history   file-name-history
                :action    ,#'consult-project-extra--find-with-concat-root
                :enabled   ,#'project-current
-               :items
-               ,(lambda () (consult-project-extra--project-files (project-root (project-current))))))
+               :items     ,(lambda ()
+			     (consult-project-extra--project-files (consult--project-root)))))
 
 (defvar consult-project-extra--source-project
   `(:name      "Known Project"

--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -92,6 +92,26 @@
   "Return the icon for the candidate CAND of completion category project."
   (all-the-icons-completion-get-icon cand 'file))
 
+;;;###autoload
+(defun consult-project-extra-project-fn (&optional may-prompt)
+  "`consult-project-extra' version of `consult--default-project-function'.
+
+Return project root directory.
+When no project is found and MAY-PROMPT is non-nil ask the user."
+  (interactive)
+  (let ((proj (project-current)))
+    (cond (proj (cond
+                 ((fboundp 'project-root) (project-root proj))
+                 ((fboundp 'project-roots) (car (project-roots proj)))))
+          (may-prompt (consult--read
+                       (mapcar #'(lambda (x) (propertize x 'face 'consult-project-extra-projects))
+                               (project-known-project-roots))
+                       :prompt   "Project: "
+                       :sort     t
+                       :category 'project
+                       :history  'consult-project-extra--project-history
+                       :annotate #'consult-project-extra--annotate-project)))))
+
 (defun consult-project-extra--find-with-concat-root (candidate)
   "Find-file concatenating root with CANDIDATE."
   (consult--file-action (concat (consult--project-root) candidate)))
@@ -112,7 +132,7 @@
                :action    ,#'consult-project-extra--find-with-concat-root
                :enabled   ,#'project-current
                :items     ,(lambda ()
-			     (consult-project-extra--project-files (consult--project-root)))))
+                             (consult-project-extra--project-files (consult--project-root)))))
 
 (defvar consult-project-extra--source-project
   `(:name      "Known Project"

--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -143,7 +143,7 @@ See `consult--multi' for a description of the source values."
   :group 'consult-project-extra)
 
 ;;;###autoload
-(defun consult-project-extra-find (&optional root)
+(defun consult-project-extra-find (&optional root other-window)
   "Create an endpoint for accessing different project sources.
 The consult view can be narrowed to: (b) current project's
 buffers,(f) current project's files and (p) to select from the
@@ -157,11 +157,18 @@ A different action is issued depending on the source. For both
 buffers and project files, the default action is to visit the
 selected element. When a known project is selected,
 `consult-project-function' is called recursively with the
-selected project as ROOT."
-  (interactive)
+selected project as ROOT.
 
-  (let ((consult-project-function (if root
-                                      (lambda (x) (ignore x) root)
+When OTHER-WINDOW is non-nil open the selected buffer in another
+window.
+
+When called Interactively PREFIX sets OTHER-WINDOW."
+  (interactive "i\nP")
+
+  (let ((consult--buffer-display (cond (other-window #'switch-to-buffer-other-window)
+                                       ((not root) #'switch-to-buffer)
+                                       (t consult--buffer-display)))
+        (consult-project-function (if root (lambda (x) (ignore x) root)
                                     consult-project-function)))
     (consult--with-project
      (consult--multi consult-project-extra-sources
@@ -172,8 +179,7 @@ selected project as ROOT."
 (defun consult-project-extra-find-other-window ()
   "Variant of `consult-project-extra' which opens in a second window."
   (interactive)
-  (let ((consult--buffer-display #'switch-to-buffer-other-window))
-    (consult-project-extra-find)))
+  (consult-project-extra-find nil t))
 
 (provide 'consult-project-extra)
 ;;; consult-project-extra.el ends here

--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -115,9 +115,11 @@ When no project is found and MAY-PROMPT is non-nil ask the user."
   `(:name      "Project File"
                :narrow    (?f . "File")
                :category  project-file
+	       :default   t
                :face      consult-file
                :history   file-name-history
                :action    ,#'consult-project-extra--find-with-concat-root
+               :new       ,#'consult-project-extra--find-with-concat-root
                :items     ,(lambda ()
                              (consult-project-extra--project-files (consult--project-root)))))
 

--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -112,26 +112,25 @@ When no project is found and MAY-PROMPT is non-nil ask the user."
     modified-source))
 
 (defvar consult-project-extra--source-file
-  `(:name      "Project File"
-               :narrow    (?f . "File")
-               :category  project-file
-	       :default   t
-               :face      consult-file
-               :history   file-name-history
-               :action    ,#'consult-project-extra--find-with-concat-root
-               :new       ,#'consult-project-extra--find-with-concat-root
-               :items     ,(lambda ()
-                             (consult-project-extra--project-files (consult--project-root)))))
+  '(:name "Project File"
+          :narrow    (?f . "File")
+          :category  project-file
+          :default   t
+          :face      consult-file
+          :history   file-name-history
+          :action    consult-project-extra--find-with-concat-root
+          :new       consult-project-extra--find-with-concat-root
+          :items     (lambda () (consult-project-extra--project-files (consult--project-root)))))
 
 (defvar consult-project-extra--source-project
-  `(:name      "Known Project"
-               :narrow    (?p . "Project")
-               :category  project
-               :face      consult-project-extra-projects
-               :history   consult-project-extra--project-history
-               :action    ,#'consult-project-extra-find
-               :annotate  ,#'consult-project-extra--annotate-project
-               :items     ,#'project-known-project-roots))
+  '(:name "Known Project"
+          :narrow    (?p . "Project")
+          :category  project
+          :face      consult-project-extra-projects
+          :history   consult-project-extra--project-history
+          :action    consult-project-extra-find
+          :annotate  consult-project-extra--annotate-project
+          :items     project-known-project-roots))
 
 (defcustom consult-project-extra-sources
   (list consult-project-extra--source-buffer

--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -5,7 +5,7 @@
 ;; Author:  Enrique Kessler Martínez
 ;; Keywords: convenience project management
 ;; Version: 0.1
-;; Package-Requires: ((emacs "27.1") (consult "0.17") (project "0.8.1"))
+;; Package-Requires: ((emacs "28.1") (consult "0.17") (project "0.8.1"))
 ;; URL: https://github.com/Qkessler/consult-project-extra
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -87,6 +87,11 @@
               (format "Project: %s" (file-name-nondirectory
                                      (directory-file-name dir))))))
 
+;; All the icons support for the new project category
+(cl-defmethod all-the-icons-completion-get-icon (cand (_cat (eql project)))
+  "Return the icon for the candidate CAND of completion category project."
+  (all-the-icons-completion-get-icon cand 'file))
+
 (defun consult-project-extra--find-with-concat-root (candidate)
   "Find-file concatenating root with CANDIDATE."
   (consult--file-action (concat (consult--project-root) candidate)))

--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -71,14 +71,21 @@
 (defun consult-project-extra--file (selected-root)
   "Create a view for selecting project files for the project at SELECTED-ROOT."
   (let ((candidate (consult--read
-              (consult-project-extra--project-files selected-root)
-              :prompt "Project File: "
-              :sort t
-              :require-match t
-              :category 'file
-              :state (consult--file-preview)
-              :history 'file-name-history)))
+                    (consult-project-extra--project-files selected-root)
+                    :prompt        "Project File: "
+                    :sort          t
+                    :require-match t
+                    :category      'project-file
+                    :state         (consult--file-preview)
+                    :history       'file-name-history)))
     (consult--file-action (concat selected-root candidate))))
+
+(defun consult-project-extra--annotate-project (dir)
+  "Annotation function for projects. Takes project root as DIR."
+  (if consult-project-extra-display-info
+      (concat (propertize " " 'display '(space :align-to center))
+              (format "Project: %s" (file-name-nondirectory
+                                     (directory-file-name dir))))))
 
 (defun consult-project-extra--find-with-concat-root (candidate)
   "Find-file concatenating root with CANDIDATE."
@@ -94,7 +101,7 @@
 (defvar consult-project-extra--source-file
   `(:name      "Project File"
                :narrow    (?f . "File")
-               :category  file
+               :category  project-file
                :face      consult-file
                :history   file-name-history
                :action    ,#'consult-project-extra--find-with-concat-root
@@ -105,13 +112,11 @@
 (defvar consult-project-extra--source-project
   `(:name      "Known Project"
                :narrow    (?p . "Project")
-               :category  'consult-project-extra-project
+               :category  project
                :face      consult-project-extra-projects
                :history   consult-project-extra--project-history
-               :annotate  ,(lambda (dir) (if consult-project-extra-display-info (progn
-                                                                                  (format "Project: %s"
-                                                                                          (file-name-nondirectory (directory-file-name dir))))))
                :action    ,#'consult-project-extra--file
+               :annotate  ,#'consult-project-extra--annotate-project
                :items     ,#'project-known-project-roots))
 
 (defcustom consult-project-extra-sources


### PR DESCRIPTION
Hi,

Take this PR as a test balloon, I'm mainly interested to know whether you're interested in upstreaming any of the changes from my personal fork that i've been using for a couple of years now. 

The main feature is recursive project selection, i.e. if you select a project in consult-project-extra it calls itself again instead of dropping you back into a vanilla file selection, imo this adds some nice consistency to the UI.

Beyond that:

- open in other window by passing prefix argument
- (optional) Embark & all-the-icons integration
- creating new files in project
- some refactoring

If you're interested in any of this I could also split this PR into more self contained feature patches, I just wanted to reach out to see if you're interested at all.

~~lou