### PR TITLE
fix: open projects relative to the correct directory

### DIFF
--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -130,7 +130,7 @@ When no project is found and MAY-PROMPT is non-nil ask the user."
           :default   t
           :face      consult-file
           :history   file-name-history
-          :action    consult--file-action
+          :action    consult-project-extra--find-with-concat-root
           :new       consult-project-extra--find-with-concat-root
           :items     (lambda () (consult-project-extra--project-files (consult--project-root)))))
 


### PR DESCRIPTION
Project file names are relative to the project root.