### PR TITLE
fix: don't retrieve relative paths for project files

### DIFF
--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -130,7 +130,7 @@ When no project is found and MAY-PROMPT is non-nil ask the user."
           :default   t
           :face      consult-file
           :history   file-name-history
-          :action    consult-project-extra--find-with-concat-root
+          :action    consult--file-action
           :new       consult-project-extra--find-with-concat-root
           :items     (lambda () (consult-project-extra--project-files (consult--project-root)))))
 

--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -69,15 +69,14 @@
   "Compute the project files given the ROOT."
   (setq root (file-name-as-directory root))
   (let* ((project (consult-project-extra--project-with-root root))
-         (current-project (project-current))
-         (project-files-relative-names (and current-project
-                                            (string= root (project-root current-project))))
          (files (project-files project))
          (root-len (length root)))
-    (mapcar (lambda (f) (cons (cond ((not (file-name-absolute-p f)) f)
-                               ((string-prefix-p root f) (substring f root-len))
-                               (t (file-relative-name f root)))
-                         f))
+    (mapcar (lambda (f) (let ((abs? (file-name-absolute-p f)))
+                     (cons (cond ((not abs?) f)
+                                 ((string-prefix-p root f) (substring f root-len))
+                                 (t (file-relative-name f root)))
+                           (cond ((not abs?) (expand-file-name f root))
+                                 (t f)))))
             files)))
 
 (defun consult-project-extra--annotate-project (dir)


### PR DESCRIPTION
fix for #18 as discussed in #17 . There's an alternative solution that retains the relative path retrieval but has a lot of overhead due to multiple calls to `expand-file-name`  [here](https://github.com/einsiedlerspiel/consult-project-extra/tree/fix-relatives).