### PR TITLE
fix: Use consult-source-project-buffer

### DIFF
--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -118,7 +118,9 @@ When no project is found and MAY-PROMPT is non-nil ask the user."
 ;; The default `consult-source-project-buffer' has the ?p as narrow key,
 ;; and therefore is in conflict with `consult-project-extra--source-project'.
 (defvar consult-project-extra--source-buffer
-  (let* ((unmodified consult-source-project-buffer)
+  (let* ((unmodified (if (boundp 'consult-source-buffer)
+                         consult-source-buffer
+                       consult--source-buffer))
          (modified-source (plist-put (plist-put unmodified :hidden nil) :narrow ?b)))
     modified-source))
 

--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -115,10 +115,10 @@ When no project is found and MAY-PROMPT is non-nil ask the user."
   "Find-file concatenating root with CANDIDATE."
   (consult--file-action (concat (consult--project-root) candidate)))
 
-;; The default `consult--source-project-buffer' has the ?p as narrow key,
+;; The default `consult-source-project-buffer' has the ?p as narrow key,
 ;; and therefore is in conflict with `consult-project-extra--source-project'.
 (defvar consult-project-extra--source-buffer
-  (let* ((unmodified consult--source-project-buffer)
+  (let* ((unmodified consult-source-project-buffer)
          (modified-source (plist-put (plist-put unmodified :hidden nil) :narrow ?b)))
     modified-source))
 


### PR DESCRIPTION
The variable was promoted to public recently, so this change uses the new variable.