### PR TITLE
Fix destructive use of plist-put

### DIFF
--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -118,11 +118,13 @@ When no project is found and MAY-PROMPT is non-nil ask the user."
 ;; The default `consult-source-project-buffer' has the ?p as narrow key,
 ;; and therefore is in conflict with `consult-project-extra--source-project'.
 (defvar consult-project-extra--source-buffer
-  (let* ((unmodified (if (boundp 'consult-source-project-buffer)
-                         consult-source-project-buffer
-                       consult--source-project-buffer))
-         (modified-source (plist-put (plist-put unmodified :hidden nil) :narrow ?b)))
-    modified-source))
+  (let* ((source (copy-sequence
+                  (if (boundp 'consult-source-project-buffer)
+                      consult-source-project-buffer
+                    consult--source-project-buffer))))
+    (setf (plist-get source :hidden) nil
+          (plist-get source :narrow) ?b)
+    source))
 
 (defvar consult-project-extra--source-file
   '(:name "Project File"


### PR DESCRIPTION
plist-put is destructive and will modify consult-source-project-buffer
in-place when the key is already present. Copying the sequence prevents
this.

This commit also replaces the nested plist-put calls with setf and
plist-get for better readability.