### PR TITLE
Use symbols for the project-sources

### DIFF
--- a/consult-project-extra.el
+++ b/consult-project-extra.el
@@ -146,9 +146,9 @@ When no project is found and MAY-PROMPT is non-nil ask the user."
           :items     project-known-project-roots))
 
 (defcustom consult-project-extra-sources
-  (list consult-project-extra--source-buffer
-        consult-project-extra--source-file
-        consult-project-extra--source-project)
+  '(consult-project-extra--source-buffer
+    consult-project-extra--source-file
+    consult-project-extra--source-project)
   "Sources used by `consult-project-extra'.
 
 See `consult--multi' for a description of the source values."


### PR DESCRIPTION
1. This matches the defcustom type.
2. This makes it possible to update the sources by updating the referenced variables.
3. This makes it easier to add/remove sources (one can simply remove/add by symbol).

`consult--multi` accepts both symbols and values.